### PR TITLE
Adding Turtle to protection.

### DIFF
--- a/ComputerCraft.json
+++ b/ComputerCraft.json
@@ -1,0 +1,10 @@
+{
+  "modid": "ComputerCraft",
+  "segments": [
+    {
+      "class": "dan200.computercraft.shared.turtle.blocks.TileTurtle",
+      "type": "tileEntity",
+      "flag": "modifyBlocks"
+    }
+  ]
+}


### PR DESCRIPTION
Known caveats:
When placing a Mining Turtle (or any turtle with a tool) to close or in a town, make it loose it's tool and become a Turtle (without any tool) when it drops on the ground.

Tested with advanced and normal Turtle with different tools.
