### PR TITLE
Adding some Wand Focus protection

### DIFF
--- a/Thaumcraft.json
+++ b/Thaumcraft.json
@@ -1,0 +1,12 @@
+{
+  "modid": "Thaumcraft",
+  "segments": [
+    {
+      "class": "thaumcraft.common.items.wands.ItemWandCasting",
+      "type": "item",
+      "itemType": "rightClickBlock",
+      "onAdjacent": false,
+      "flag": "modifyBlocks"
+    }
+  ]
+}


### PR DESCRIPTION
Equal Trade, Excavation, Portable Hole, AE Wrench and Warding.
and people can't drain Vis from a Aura Node inside protected areas
