### PR TITLE
Fix: Matter Cannon breaking blocks on right click

### DIFF
--- a/AE2.json
+++ b/AE2.json
@@ -25,7 +25,7 @@
     {
       "class": "appeng.items.tools.powered.ToolMassCannon",
       "type": "item",
-      "actions": "RIGHT_CLICK_AIR",
+      "actions": [ "RIGHT_CLICK_AIR", "RIGHT_CLICK_BLOCK" ],
       "isAdjacent": false,
       "flags": "MODIFY",
       "range": 32

--- a/AE2.json
+++ b/AE2.json
@@ -36,6 +36,13 @@
       "actions": "RIGHT_CLICK_BLOCK",
       "isAdjacent": false,
       "flags": "MODIFY"
+    },
+    {
+      "class": "appeng.items.tools.powered.ToolColorApplicator",
+      "type": "item",
+      "actions": "RIGHT_CLICK_BLOCK",
+      "isAdjacent": false,
+      "flags": "MODIFY"
     }
   ]
 }


### PR DESCRIPTION
Matter Cannon could still be used when right clicking a block directly.
